### PR TITLE
Impose size limits on save, login remebered across browser windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ MolViewStories uses OAuth2 with PKCE for secure authentication via Life Science 
 ### Session Management
 
 - Sessions last 8-12 hours (Life Science AAI default)
-- Tokens stored in browser sessionStorage
+- Tokens stored in browser localStorage
 - Automatic token refresh when possible
 - Login status synchronized across browser tabs
 - Sessions expire automatically when tokens become invalid

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -26,7 +26,7 @@ import { CheckCircle, XCircle, AlertCircle, Home, RefreshCw, Loader2 } from 'luc
 export default function AuthPage() {
   const router = useRouter();
   const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
-  const [message, setMessage] = useState('Authenticating...');
+  const [message, setMessage] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [timeoutReached, setTimeoutReached] = useState(false);
 

--- a/src/app/state/save-dialog-actions.ts
+++ b/src/app/state/save-dialog-actions.ts
@@ -12,7 +12,9 @@ import { getMVSData, setIsDirty, setSessionIdUrl } from './actions';
 
 // File size validation utility
 // Note that file size is also checked at the API, this is a safety check to avoid expensive sending of oversized data.
-function validateDataSize(data: Uint8Array | string, maxSizeMB: number = 50): void {
+const MAX_FILE_SIZE_MB = 50; // Keep in sync with backend limit
+
+function validateDataSize(data: Uint8Array | string, maxSizeMB: number = MAX_FILE_SIZE_MB): void {
   const maxSizeBytes = maxSizeMB * 1024 * 1024;
   let sizeBytes: number;
   
@@ -229,7 +231,7 @@ async function saveToAPI(
     // Handle specific HTTP status codes with user-friendly messages
     if (response.status === 413) {
       const operation = endpoint === 'session' ? 'SAVE' : 'PUBLISH';
-      throw new Error(`${operation} FAILED: Session too large (over 50MB limit). Please reduce complexity or remove large assets to continue.`);
+      throw new Error(`${operation} FAILED: Session too large (over ${MAX_FILE_SIZE_MB}MB limit). Please reduce complexity or remove large assets to continue.`);
     }
     
     const errorText = await response.text();

--- a/src/app/state/save-dialog-actions.ts
+++ b/src/app/state/save-dialog-actions.ts
@@ -10,6 +10,25 @@ import { API_CONFIG } from '@/lib/config';
 import { encodeUint8ArrayToBase64 } from '@/lib/data-utils';
 import { getMVSData, setIsDirty, setSessionIdUrl } from './actions';
 
+// File size validation utility
+// Note that file size is also checked at the API, this is a safety check to avoid expensive sending of oversized data.
+function validateDataSize(data: Uint8Array | string, maxSizeMB: number = 50): void {
+  const maxSizeBytes = maxSizeMB * 1024 * 1024;
+  let sizeBytes: number;
+  
+  if (data instanceof Uint8Array) {
+    sizeBytes = data.byteLength;
+  } else {
+    // For string data (JSON), calculate the byte size
+    sizeBytes = new Blob([data]).size;
+  }
+  
+  if (sizeBytes > maxSizeBytes) {
+    const sizeMB = (sizeBytes / 1024 / 1024).toFixed(1);
+    throw new Error(`SAVE FAILED: Session too large (${sizeMB}MB, max: ${maxSizeMB}MB). Please reduce complexity or remove large assets to continue.`);
+  }
+}
+
 // SaveDialog Actions
 export function openSaveDialog() {
   const sessionId = new URL(window.location.href).searchParams.get('sessionId') ?? undefined;
@@ -58,6 +77,7 @@ export async function publishStory(options?: { storyId?: string }): Promise<bool
   };
 
   try {
+   
     // Prepare story data
     const data = await prepareStateData(story);
 
@@ -84,7 +104,23 @@ export async function publishStory(options?: { storyId?: string }): Promise<bool
     return true;
   } catch (error) {
     console.error('Share failed:', error);
-    toast.error(error instanceof Error ? error.message : 'Failed to share story');
+    
+    const errorMessage = error instanceof Error ? error.message : 'PUBLISH FAILED: Unknown error occurred';
+    const isFileSizeError = errorMessage.includes('too large') || errorMessage.includes('FAILED') || errorMessage.includes('maximum allowed');
+    
+    // Add explicit failure prefix if not already present
+    const displayMessage = errorMessage.includes('FAILED') ? errorMessage : `PUBLISH FAILED: ${errorMessage}`;
+    
+    toast.error(displayMessage, {
+      duration: isFileSizeError ? 10000 : 5000, // 10 seconds for file size errors, 5 seconds for others
+      closeButton: true, // Allow manual dismissal
+      style: isFileSizeError ? {
+        backgroundColor: '#fee2e2', // Light red background for file size errors
+        borderColor: '#dc2626', // Red border
+        color: '#991b1b' // Dark red text
+      } : undefined,
+    });
+    
     return false;
   }
 }
@@ -101,18 +137,27 @@ async function prepareSessionData(story: Story): Promise<Uint8Array> {
     return await deflate(ctx, encoded, { level: 3 });
   }).run();
 
+  // Validate file size before proceeding
+  validateDataSize(deflated);
+
   return deflated;
 }
 
 async function prepareStateData(story: Story): Promise<Uint8Array | string> {
   const mvsData = await getMVSData(story);
 
+  let finalData: Uint8Array | string;
   if (mvsData instanceof Uint8Array) {
-    return mvsData;
+    finalData = mvsData;
   } else {
     // Convert to JSON string for API
-    return JSON.stringify(mvsData);
+    finalData = JSON.stringify(mvsData);
   }
+
+  // Validate file size before proceeding
+  validateDataSize(finalData);
+
+  return finalData;
 }
 
 async function saveToAPI(
@@ -157,6 +202,15 @@ async function saveToAPI(
     requestBody.filename = formData.title.trim() + getFileExtension(endpoint, data);
   }
 
+  // Final validation: check the size of the JSON payload that will be sent
+  const jsonPayload = JSON.stringify(requestBody);
+  try {
+    validateDataSize(jsonPayload);
+  } catch (error) {
+    const operation = endpoint === 'session' ? 'SAVE' : 'PUBLISH';
+    throw new Error(error instanceof Error ? error.message.replace('SAVE FAILED', `${operation} FAILED`) : `${operation} FAILED: Request payload too large`);
+  }
+
   // If sessionId is provided, update existing session; otherwise create new
   const url = sessionId
     ? `${API_CONFIG.baseUrl}/api/${endpoint}/${sessionId}`
@@ -168,12 +222,31 @@ async function saveToAPI(
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(requestBody),
+    body: jsonPayload,
   });
 
   if (!response.ok) {
+    // Handle specific HTTP status codes with user-friendly messages
+    if (response.status === 413) {
+      const operation = endpoint === 'session' ? 'SAVE' : 'PUBLISH';
+      throw new Error(`${operation} FAILED: Session too large (over 50MB limit). Please reduce complexity or remove large assets to continue.`);
+    }
+    
     const errorText = await response.text();
-    throw new Error(`Failed to save ${endpoint}: ${response.statusText} - ${errorText}`);
+    
+    // Try to parse structured error from backend
+    try {
+      const errorData = JSON.parse(errorText);
+      if (errorData.message) {
+        const operation = endpoint === 'session' ? 'Save' : 'Publish';
+        throw new Error(`${operation} failed: ${errorData.message}`);
+      }
+    } catch {
+      // Fall back to generic error if parsing fails
+    }
+    
+    const operation = endpoint === 'session' ? 'save' : 'publish';
+    throw new Error(`Failed to ${operation}: ${response.statusText}`);
   }
 
   return await response.json();
@@ -189,10 +262,10 @@ export async function performSaveSession(sessionId?: string): Promise<boolean> {
     description: saveDialog.data?.note || '',
   };
 
-  // Set saving state
-  store.set(SaveDialogAtom, { ...saveDialog, status: 'processing' });
-
   try {
+    // Set saving state after size check passes
+    store.set(SaveDialogAtom, { ...saveDialog, status: 'processing' });
+
     const data = await prepareSessionData(story);
     const result = (await saveToAPI(data, 'session', formData, sessionId)) as SessionMetadata;
 
@@ -243,7 +316,23 @@ export async function performSaveSession(sessionId?: string): Promise<boolean> {
     return true;
   } catch (error) {
     console.error('Save failed:', error);
-    toast.error(error instanceof Error ? error.message : 'Failed to save');
+    
+    const errorMessage = error instanceof Error ? error.message : 'SAVE FAILED: Unknown error occurred';
+    const isFileSizeError = errorMessage.includes('too large') || errorMessage.includes('FAILED') || errorMessage.includes('maximum allowed');
+    
+    // Add explicit failure prefix if not already present
+    const displayMessage = errorMessage.includes('FAILED') ? errorMessage : `SAVE FAILED: ${errorMessage}`;
+    
+    toast.error(displayMessage, {
+      duration: isFileSizeError ? 10000 : 5000, // 10 seconds for file size errors, 5 seconds for others
+      closeButton: true, // Allow manual dismissal
+      style: isFileSizeError ? {
+        backgroundColor: '#fee2e2', // Light red background for file size errors
+        borderColor: '#dc2626', // Red border
+        color: '#991b1b' // Dark red text
+      } : undefined,
+    });
+    
     return false;
   } finally {
     // Reset saving state

--- a/src/components/story-builder/file-operations/ImportSessionDialog.tsx
+++ b/src/components/story-builder/file-operations/ImportSessionDialog.tsx
@@ -67,7 +67,7 @@ export function ImportSessionDialog() {
               ) : (
                 <div className='space-y-2'>
                   <p className='text-gray-600'>Drag & drop session file here, or click to select files</p>
-                  <p className='text-sm text-gray-400'>.mvsession</p>
+                  <p className='text-sm text-gray-400'>.mvstory</p>
                 </div>
               )}
             </div>

--- a/src/components/story-builder/file-operations/ImportSessionDialog.tsx
+++ b/src/components/story-builder/file-operations/ImportSessionDialog.tsx
@@ -67,7 +67,7 @@ export function ImportSessionDialog() {
               ) : (
                 <div className='space-y-2'>
                   <p className='text-gray-600'>Drag & drop session file here, or click to select files</p>
-                  <p className='text-sm text-gray-400'>.mvstory</p>
+                  <p className='text-sm text-gray-400'>{SessionFileExtension}</p>
                 </div>
               )}
             </div>

--- a/src/components/story-builder/file-operations/PublishModal.tsx
+++ b/src/components/story-builder/file-operations/PublishModal.tsx
@@ -71,7 +71,6 @@ export function PublishModal() {
       setActiveTab('new');
     } catch (err) {
       console.error('Failed to publish story: ', err);
-      toast.error(`Failed to publish the story`);
     } finally {
       setState((prev) => ({ ...prev, status: 'idle' }));
     }

--- a/src/hooks/useStoriesQueries.ts
+++ b/src/hooks/useStoriesQueries.ts
@@ -103,11 +103,13 @@ export function usePublishStory() {
     onSuccess: () => {
       // Invalidate and refetch stories to show the new/updated story
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.stories });
-      toast.success('Story published successfully!');
     },
     onError: (error) => {
-      console.error('Failed to publish story:', error);
-      toast.error('Failed to publish story');
+      console.error('Failed to publish story (mutation):', error);
+      const errorMessage = error instanceof Error ? error.message : 'Failed to publish story';
+      if (!errorMessage.includes('too large') && !errorMessage.includes('maximum allowed')) {
+        toast.error('Failed to publish story');
+      }
     },
   });
 }

--- a/src/lib/auth/token-manager.ts
+++ b/src/lib/auth/token-manager.ts
@@ -29,7 +29,7 @@ export function saveTokens(tokens: Omit<AuthTokens, 'expires_at'>): void {
   };
 
   try {
-    sessionStorage.setItem('oauth_tokens', JSON.stringify(tokensWithExpiry));
+    localStorage.setItem('oauth_tokens', JSON.stringify(tokensWithExpiry));
     triggerAuthRefresh();
   } catch (error) {
     console.warn('Failed to save tokens:', error);
@@ -40,7 +40,7 @@ export function clearTokens(): void {
   if (typeof window === 'undefined') return;
 
   try {
-    sessionStorage.removeItem('oauth_tokens');
+    localStorage.removeItem('oauth_tokens');
     triggerAuthRefresh();
   } catch (error) {
     console.warn('Failed to clear tokens:', error);
@@ -52,7 +52,7 @@ export async function getValidTokens(): Promise<AuthTokens | null> {
   if (typeof window === 'undefined') return null;
 
   try {
-    const saved = sessionStorage.getItem('oauth_tokens');
+    const saved = localStorage.getItem('oauth_tokens');
     if (!saved) return null;
 
     const tokens: AuthTokens = JSON.parse(saved);
@@ -133,7 +133,7 @@ export async function refreshAccessToken(): Promise<AuthTokens | null> {
   // Get tokens directly from storage, even if expired
   let currentTokens: AuthTokens;
   try {
-    const saved = sessionStorage.getItem('oauth_tokens');
+    const saved = localStorage.getItem('oauth_tokens');
     if (!saved) {
       return null;
     }

--- a/src/lib/pkce-auth-context.tsx
+++ b/src/lib/pkce-auth-context.tsx
@@ -246,7 +246,7 @@ export function PKCEAuthProvider({ children }: { children: React.ReactNode }) {
     const checkTokenExpiry = async () => {
       try {
         // Check if we have any tokens in storage
-        const saved = sessionStorage.getItem('oauth_tokens');
+        const saved = localStorage.getItem('oauth_tokens');
         if (!saved) return;
 
         const tokens = JSON.parse(saved);


### PR DESCRIPTION
<!-- Thank you for contributing to mol-view-stories -->

# Description
Several minor fixes for save sessions, host stories functionality:
- added file size limit that's checked on backend, but also on frontend to give the "file too large" feedback asap:
![file-too-large](https://github.com/user-attachments/assets/4d7872bb-8359-401e-84c9-5e68e7156455)
- changed `sessionStorage` for `localStorage` to remember login across browser tabs and windows
- removed extra "authenticating..." message
- replaced `.mvsession` with `.mvstory` in import