### PR TITLE
delete old .mvsj/.mvsx on story save to keep single format

### DIFF
--- a/@mol-view-stories/webapp/CHANGELOG.md
+++ b/@mol-view-stories/webapp/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file, following t
 
 ### Fixed
 - **Auth Page**: Fixed infinite loop when no code or error is present
+- **Story Format**: Fixed story format change issue when updating story
 
 ## [v1.0.0]
 

--- a/@mol-view-stories/webapp/src/app/state/save-dialog-actions.ts
+++ b/@mol-view-stories/webapp/src/app/state/save-dialog-actions.ts
@@ -70,7 +70,7 @@ export function updateSaveDialogFormField(field: 'note', value: string) {
 }
 
 // Direct share story function - saves as public story and shows share modal
-export async function publishStory(options?: { storyId?: string }): Promise<boolean> {
+export async function publishStory(options?: { storyId?: string }): Promise<{ success: boolean; storyId?: string }> {
   const store = getDefaultStore();
   const story = store.get(StoryAtom);
 
@@ -105,7 +105,7 @@ export async function publishStory(options?: { storyId?: string }): Promise<bool
       });
     }
 
-    return true;
+    return { success: true, storyId: result.id };
   } catch (error) {
     console.error('Share failed:', error);
 
@@ -128,7 +128,7 @@ export async function publishStory(options?: { storyId?: string }): Promise<bool
         : undefined,
     });
 
-    return false;
+    return { success: false };
   }
 }
 

--- a/@mol-view-stories/webapp/src/hooks/useStoriesQueries.ts
+++ b/@mol-view-stories/webapp/src/hooks/useStoriesQueries.ts
@@ -100,9 +100,13 @@ export function usePublishStory() {
 
   return useMutation({
     mutationFn: ({ storyId }: { storyId?: string }) => publishStory({ storyId }),
-    onSuccess: () => {
+    onSuccess: (result) => {
       // Invalidate and refetch stories to show the new/updated story
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.stories });
+
+      if (result.storyId) {
+        queryClient.invalidateQueries({ queryKey: QUERY_KEYS.storyFormat(result.storyId) });
+      }
     },
     onError: (error) => {
       console.error('Failed to publish story (mutation):', error);


### PR DESCRIPTION
<!-- Thank you for contributing to mol-view-stories -->

# Description

## Problem

Updating a story from .mvsj → .mvsx (or vice versa) left both data files in storage. The API could then serve the wrong format depending on lookup order, and the UI thought the story was still the old format.

## Solution
On update, we now remove any `data.mvsj/data.mvsx` not matching the target. We invoke cleanup from `_save_data` (FormData create/update path) and `_save_updated_story_data` (legacy JSON update path).

UI modals were updated to fetch the freshly saved story format and invalidate the cached format on publish/update.


## Result
Storage always contains exactly one story data file (data.mvsj or data.mvsx) per story, and format detection/serving is consistent.

Tested locally (mvsj -> mvsx; mvsx -> mvsj).

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`