### PR TITLE
Accept .vtp/.ply/.obj in the asset upload allowlist

### DIFF
--- a/@mol-view-stories/webapp/src/components/story-builder/StoryOptions.tsx
+++ b/@mol-view-stories/webapp/src/components/story-builder/StoryOptions.tsx
@@ -181,6 +181,10 @@ function FileUploadZone() {
       'application/x-map': ['.map'],
       'application/x-dx': ['.dx'],
       'application/x-dxbin': ['.dxbin'],
+      // Shapes (MVS `shape` node)
+      'application/x-vtp': ['.vtp'],
+      'application/x-ply': ['.ply'],
+      'model/obj': ['.obj'],
       // Images
       'image/png': ['.png'],
       'image/jpeg': ['.jpg', '.jpeg'],


### PR DESCRIPTION
The MVS `shape` node loads meshes from VTP, PLY and OBJ, but the story asset dropzone's `accept` map does not list those extensions. Since `fileRejections` is never read, a dropped `.vtp` is silently discarded — no error, no toast, and no visible reason why nothing happened.

Four lines, adding the three MIME/extension entries alongside the existing Molecules / Volumes / Images / Audio groups.

Independent of the molstar version: harmless before the `shape` node ships, and required after. Related: molstar/molstar#1916 and molstar/mol-view-spec#111.

## Actions

- [x] `pnpm tsc:check` clean
- [x] `pnpm prettier:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)